### PR TITLE
RC6 - More Optimization and Popping Audio Fix

### DIFF
--- a/src/audio/synthesis.c
+++ b/src/audio/synthesis.c
@@ -346,10 +346,16 @@ u64 *synthesis_execute(u64 *cmdBuf, s32 *writtenCmds, s16 *aiBuf, s32 bufLen) {
                 chunkLen += 8;
             }
         }
+
+        profiler_3ds_log_time(0);
         process_sequences(i - 1);
+        profiler_3ds_log_time(19); // Sequence Processing
+        
+        
         if (gSynthesisReverb.useReverb != 0) {
             prepare_reverb_ring_buffer(chunkLen, gAudioUpdatesPerFrame - i);
         }
+
         cmd = synthesis_do_one_audio_update((s16 *) aiBufPtr, chunkLen, cmd, gAudioUpdatesPerFrame - i);
         bufLen -= chunkLen;
         aiBufPtr += chunkLen;

--- a/src/pc/audio/audio_3ds.c
+++ b/src/pc/audio/audio_3ds.c
@@ -103,7 +103,10 @@ static void audio_3ds_play_internal(const uint8_t *src, size_t len_total, size_t
     if (len_to_copy != 0)
         memcpy(dst, src, len_to_copy);
 
-    DSP_FlushDataCache(dst, len_total);
+    // DSP_FlushDataCache is slow if AppCpuLimit is set high for some reason.
+    // svcFlushProcessDataCache is much faster and still works perfectly.
+    // DSP_FlushDataCache(dst, len_total);
+    svcFlushProcessDataCache(CUR_PROCESS_HANDLE, dst, len_total);
     
     // Actually play the data
     sDspBuffers[sNextBuffer].nsamples = len_total / 4;

--- a/src/pc/audio/audio_3ds.c
+++ b/src/pc/audio/audio_3ds.c
@@ -36,6 +36,7 @@ enum N3dsCpu s_audio_cpu = OLD_CORE_0;
 
 volatile __3ds_s32 s_audio_frames_to_tick = 0;
 volatile __3ds_s32 s_audio_frames_to_process = 0;
+volatile bool s_audio_thread_processing = false;
 
 // Synchronization variables
 static volatile bool running = true;
@@ -165,7 +166,13 @@ static void audio_3ds_loop()
     
     while (running)
     {
-        if (s_audio_frames_to_process > 0)
+        s_audio_thread_processing = s_audio_frames_to_process > 0;
+
+        // In an ideal world, we would just continually run audio synthesis.
+        // This would give an N64-like behavior, with no audio choppiness on slowdown.
+        // However, due to race conditions, that is currently non-viable.
+        // If the audio thread's DMA were ripped out, it would likely work.
+        if (s_audio_thread_processing)
             audio_3ds_run_one_frame();
         else
             N3DS_AUDIO_SLEEP_FUNC(N3DS_AUDIO_SLEEP_DURATION_NANOS);

--- a/src/pc/audio/audio_3ds_threading.h
+++ b/src/pc/audio/audio_3ds_threading.h
@@ -71,5 +71,11 @@ extern enum N3dsCpu s_audio_cpu;
 extern volatile __3ds_s32 s_audio_frames_to_tick;
 extern volatile __3ds_s32 s_audio_frames_to_process;
 
+// This is purely an informative value.
+// It is set to true when it acknowledges a new frame to process,
+// and to false when the audio thread begins spinning.
+// Do not use this for bi-directional synchronization!
+extern volatile bool s_audio_thread_processing;
+
 #endif
 #endif

--- a/src/pc/gfx/gfx_3ds.c
+++ b/src/pc/gfx/gfx_3ds.c
@@ -270,7 +270,7 @@ static void gfx_3ds_apt_hook(APT_HookType hook, UNUSED void* param)
         else
             fprintf(stderr, "Error: APT_SetAppCpuTimeLimit failed to set to %hhd on %s.\n", limit, eventName);
     } else {
-        printf("Not setting AppCpuTimeLimit because audio code is %d", s_audio_cpu);
+        printf("Not setting AppCpuTimeLimit because audio is running on CPU %d.\n", s_audio_cpu);
     }
 }
 

--- a/src/pc/gfx/gfx_3ds.c
+++ b/src/pc/gfx/gfx_3ds.c
@@ -216,12 +216,7 @@ static void gfx_3ds_handle_touch() {
 // Called whenever a 3DS OS event is fired.
 static void gfx_3ds_apt_hook(APT_HookType hook, UNUSED void* param)
 {
-    if (s_audio_cpu != OLD_CORE_1) {
-        printf("APT hook ignored with audio CPU: %d.\n", s_audio_cpu);
-        return;
-    }
-
-    char* eventName = "unknown event";
+    char* eventName = "unknown";
 
     switch (hook) {
         case APTHOOK_ONSLEEP: // Lid closed
@@ -253,9 +248,11 @@ static void gfx_3ds_apt_hook(APT_HookType hook, UNUSED void* param)
             return;
             
         default: // Should never happen
-            perror("Unknown APT hook type.\n");
+            fprintf(stderr, "Unknown APT hook type %d.\n", hook);
             return;
     }
+
+    printf("AptHook caught: %s.\n", eventName);
 
     // Wait for async audio to finish. Synchronous will already be done anyway.
     if (s_audio_cpu != OLD_CORE_0) {
@@ -269,9 +266,9 @@ static void gfx_3ds_apt_hook(APT_HookType hook, UNUSED void* param)
         const u8 limit = appSuspendCounter > 0 ? N3DS_AUDIO_CORE_1_LIMIT_IDLE : N3DS_AUDIO_CORE_1_LIMIT;
 
         if (R_SUCCEEDED(APT_SetAppCpuTimeLimit(limit)))
-            printf("APT_SetAppCpuTimeLimit set to %hhd on %s.\n", limit, eventName);
+            printf("AppCpuTimeLimit set to %hhd.\n", limit);
         else
-            fprintf(stderr, "Error: APT_SetAppCpuTimeLimit failed to set to %hhd on %s.\n", limit, eventName);
+            fprintf(stderr, "Error: AppCpuTimeLimit failed to set to %hhd.\n", limit);
     } else {
         printf("Not setting AppCpuTimeLimit because audio is running on CPU %d.\n", s_audio_cpu);
     }

--- a/src/pc/gfx/gfx_3ds.c
+++ b/src/pc/gfx/gfx_3ds.c
@@ -257,11 +257,14 @@ static void gfx_3ds_apt_hook(APT_HookType hook, UNUSED void* param)
             return;
     }
 
-    // Wait for audio to finish
-    if (appSuspendCounter > 0)
-        while (s_audio_frames_to_process > 0)
-            svcSleepThread(N3DS_AUDIO_SLEEP_DURATION_NANOS);
+    // Wait for async audio to finish. Synchronous will already be done anyway.
+    if (s_audio_cpu != OLD_CORE_0) {
+        if (appSuspendCounter > 0)
+            while (s_audio_frames_to_process > 0)
+                svcSleepThread(N3DS_AUDIO_SLEEP_DURATION_NANOS);
+    }
 
+    // Lower CPU priority only if applicable
     if (s_audio_cpu == OLD_CORE_1) {
         const u8 limit = appSuspendCounter > 0 ? N3DS_AUDIO_CORE_1_LIMIT_IDLE : N3DS_AUDIO_CORE_1_LIMIT;
 

--- a/src/pc/gfx/gfx_3ds.c
+++ b/src/pc/gfx/gfx_3ds.c
@@ -94,7 +94,7 @@ static void initialise_screens()
 {
     C3D_Init(C3D_DEFAULT_CMDBUF_SIZE);
 
-    bool useAA = gfx_config.useAA;
+    bool useAA = gfx_config.useAA && n3dsModel != 3; // old 2DS does not support 800px
     bool useWide = gfx_config.useWide && n3dsModel != 3; // old 2DS does not support 800px
 
     u32 transferFlags = DISPLAY_TRANSFER_FLAGS;

--- a/src/pc/gfx/gfx_3ds.c
+++ b/src/pc/gfx/gfx_3ds.c
@@ -262,12 +262,16 @@ static void gfx_3ds_apt_hook(APT_HookType hook, UNUSED void* param)
         while (s_audio_frames_to_process > 0)
             svcSleepThread(N3DS_AUDIO_SLEEP_DURATION_NANOS);
 
-    const u8 limit = appSuspendCounter > 0 ? N3DS_AUDIO_CORE_1_LIMIT_IDLE : N3DS_AUDIO_CORE_1_LIMIT;
+    if (s_audio_cpu == OLD_CORE_1) {
+        const u8 limit = appSuspendCounter > 0 ? N3DS_AUDIO_CORE_1_LIMIT_IDLE : N3DS_AUDIO_CORE_1_LIMIT;
 
-    if (R_SUCCEEDED(APT_SetAppCpuTimeLimit(limit)))
-        printf("APT_SetAppCpuTimeLimit set to %hhd on %s.\n", limit, eventName);
-    else
-        fprintf(stderr, "Error: APT_SetAppCpuTimeLimit failed to set to %hhd on %s.\n", limit, eventName);
+        if (R_SUCCEEDED(APT_SetAppCpuTimeLimit(limit)))
+            printf("APT_SetAppCpuTimeLimit set to %hhd on %s.\n", limit, eventName);
+        else
+            fprintf(stderr, "Error: APT_SetAppCpuTimeLimit failed to set to %hhd on %s.\n", limit, eventName);
+    } else {
+        printf("Not setting AppCpuTimeLimit because audio code is %d", s_audio_cpu);
+    }
 }
 
 static void gfx_3ds_init(UNUSED const char *game_name, UNUSED bool start_in_fullscreen)

--- a/src/pc/mixer_implementations/mixer_3ds.c
+++ b/src/pc/mixer_implementations/mixer_3ds.c
@@ -334,10 +334,10 @@ void aResampleImpl(const uint8_t flags, const uint16_t pitch, RESAMPLE_STATE sta
         const int16_t* const tbl = resample_table[(pitch_accumulator << 6) >> 16];
 
 #ifdef AUDIO_USE_ACCURATE_MATH
-        *out = ((in[0] * tbl[0] + 0x4000) >> 15) +
-               ((in[1] * tbl[1] + 0x4000) >> 15) +
-               ((in[2] * tbl[2] + 0x4000) >> 15) +
-               ((in[3] * tbl[3] + 0x4000) >> 15);
+        *out = clamp16(((in[0] * tbl[0] + 0x4000) >> 15) +
+                       ((in[1] * tbl[1] + 0x4000) >> 15) +
+                       ((in[2] * tbl[2] + 0x4000) >> 15) +
+                       ((in[3] * tbl[3] + 0x4000) >> 15));
 #else
         // Inaccurate rounding
         *out = clamp16((in[0] * tbl[0] +

--- a/src/pc/mixer_implementations/mixer_3ds_simd32.c
+++ b/src/pc/mixer_implementations/mixer_3ds_simd32.c
@@ -1,6 +1,5 @@
 #if __ARM_FEATURE_SIMD32 == 1 && __ARM_FEATURE_SAT == 1 // Useful for debugging
 
-#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/pc/mixer_implementations/mixer_3ds_simd32.c
+++ b/src/pc/mixer_implementations/mixer_3ds_simd32.c
@@ -480,7 +480,6 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
 
 #define ENV_MIXER_LOOP_AUX  for (int i = 0; i < nSamples; i++, in++, dry[0]++, dry[1]++, wet[0]++, wet[1]++)
 #define ENV_MIXER_LOOP_NORM for (int i = 0; i < nSamples; i++, in++, dry[0]++, dry[1]++)
-#define ENV_MIXER_CLAMP32(v) clamp32_upper(v)
 
     // If Aux is set, we output wet and dry, else only dry.
     // We outline rate to reduce logic within the loop.
@@ -495,8 +494,8 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
                                          envMixerGetVolumeIncreasing(vols[1][i & 7], target_s[1])};
 
                     // Vols should never be negative
-                    vols[0][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[0]) * rate[0]) >> 16);
-                    vols[1][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[1]) * rate[1]) >> 16);
+                    vols[0][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[0]) * rate[0]) >> 16);
+                    vols[1][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[1]) * rate[1]) >> 16);
 
                     volume[0] >>= 16;
                     volume[1] >>= 16;
@@ -510,8 +509,8 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
                                          envMixerGetVolumeDecreasing(vols[1][i & 7], target_s[1])};
 
                     // Vols should never be negative
-                    vols[0][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[0]) * rate[0]) >> 16);
-                    vols[1][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[1]) * rate[1]) >> 16);
+                    vols[0][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[0]) * rate[0]) >> 16);
+                    vols[1][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[1]) * rate[1]) >> 16);
 
                     volume[0] >>= 16;
                     volume[1] >>= 16;
@@ -526,8 +525,8 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
                                          envMixerGetVolumeIncreasing(vols[1][i & 7], target_s[1])};
 
                     // Vols should never be negative
-                    vols[0][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[0]) * rate[0]) >> 16);
-                    vols[1][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[1]) * rate[1]) >> 16);
+                    vols[0][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[0]) * rate[0]) >> 16);
+                    vols[1][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[1]) * rate[1]) >> 16);
 
                     volume[0] >>= 16;
                     volume[1] >>= 16;
@@ -541,14 +540,16 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
                                          envMixerGetVolumeDecreasing(vols[1][i & 7], target_s[1])};
 
                     // Vols should never be negative
-                    vols[0][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[0]) * rate[0]) >> 16);
-                    vols[1][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[1]) * rate[1]) >> 16);
+                    vols[0][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[0]) * rate[0]) >> 16);
+                    vols[1][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[1]) * rate[1]) >> 16);
 
                     volume[0] >>= 16;
                     volume[1] >>= 16;
             
                     envMixerProcessAudioAux(*in, dry, wet, volume, vol_dry, vol_wet);
                 }
+    
+    // AUX is not set, so ignore the wet channels
     else
         if (rate[0] >= 0x10000)
             if (rate[1] >= 0x10000)
@@ -558,8 +559,8 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
                                          envMixerGetVolumeIncreasing(vols[1][i & 7], target_s[1])};
 
                     // Vols should never be negative
-                    vols[0][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[0]) * rate[0]) >> 16);
-                    vols[1][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[1]) * rate[1]) >> 16);
+                    vols[0][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[0]) * rate[0]) >> 16);
+                    vols[1][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[1]) * rate[1]) >> 16);
 
                     volume[0] >>= 16;
                     volume[1] >>= 16;
@@ -573,8 +574,8 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
                                          envMixerGetVolumeDecreasing(vols[1][i & 7], target_s[1])};
 
                     // Vols should never be negative
-                    vols[0][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[0]) * rate[0]) >> 16);
-                    vols[1][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[1]) * rate[1]) >> 16);
+                    vols[0][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[0]) * rate[0]) >> 16);
+                    vols[1][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[1]) * rate[1]) >> 16);
 
                     volume[0] >>= 16;
                     volume[1] >>= 16;
@@ -589,8 +590,8 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
                                          envMixerGetVolumeIncreasing(vols[1][i & 7], target_s[1])};
 
                     // Vols should never be negative
-                    vols[0][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[0]) * rate[0]) >> 16);
-                    vols[1][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[1]) * rate[1]) >> 16);
+                    vols[0][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[0]) * rate[0]) >> 16);
+                    vols[1][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[1]) * rate[1]) >> 16);
 
                     volume[0] >>= 16;
                     volume[1] >>= 16;
@@ -604,8 +605,8 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
                                          envMixerGetVolumeDecreasing(vols[1][i & 7], target_s[1])};
 
                     // Vols should never be negative
-                    vols[0][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[0]) * rate[0]) >> 16);
-                    vols[1][i & 7] = (int32_t) ENV_MIXER_CLAMP32((((int64_t) volume[1]) * rate[1]) >> 16);
+                    vols[0][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[0]) * rate[0]) >> 16);
+                    vols[1][i & 7] = (int32_t) clamp32_upper((((int64_t) volume[1]) * rate[1]) >> 16);
 
                     volume[0] >>= 16;
                     volume[1] >>= 16;

--- a/src/pc/mixer_implementations/mixer_3ds_simd32.c
+++ b/src/pc/mixer_implementations/mixer_3ds_simd32.c
@@ -339,10 +339,10 @@ void aResampleImpl(const uint8_t flags, const uint16_t pitch, RESAMPLE_STATE sta
 
 #ifdef AUDIO_USE_ACCURATE_MATH
         const int16_t* const tbl = resample_table[(pitch_accumulator << 6) >> 16];
-        *out = ((in[0] * tbl[0] + 0x4000) >> 15) +
-               ((in[1] * tbl[1] + 0x4000) >> 15) +
-               ((in[2] * tbl[2] + 0x4000) >> 15) +
-               ((in[3] * tbl[3] + 0x4000) >> 15);
+        *out = clamp16(((in[0] * tbl[0] + 0x4000) >> 15) +
+                       ((in[1] * tbl[1] + 0x4000) >> 15) +
+                       ((in[2] * tbl[2] + 0x4000) >> 15) +
+                       ((in[3] * tbl[3] + 0x4000) >> 15));
 #else
         // Inaccurate rounding
         const int32_t* const tbl = (const int32_t* const) resample_table[(pitch_accumulator << 6) >> 16];

--- a/src/pc/mixer_implementations/mixer_3ds_simd32.c
+++ b/src/pc/mixer_implementations/mixer_3ds_simd32.c
@@ -390,6 +390,7 @@ static ALWAYS_INLINE int32_t envMixerGetVolumeDecreasing(const int32_t volume, c
 
 
 // Processes audio with the AUX flag, writing both dry and wet buffers.
+// Thanks to michi and Wuerfel_21 for help in optimizing the underlying math here.
 static ALWAYS_INLINE void envMixerProcessAudioAux (
     const int16_t in_val,
     int16_t* dry[2],
@@ -412,6 +413,7 @@ static ALWAYS_INLINE void envMixerProcessAudioAux (
 }
 
 // Processes audio without the AUX flag, writing only dry buffers.
+// Thanks to michi and Wuerfel_21 for help in optimizing the underlying math here.
 static ALWAYS_INLINE void envMixerProcessAudioNormal (
     const int16_t in_val,
     int16_t* dry[2],

--- a/src/pc/mixer_implementations/mixer_3ds_simd32.c
+++ b/src/pc/mixer_implementations/mixer_3ds_simd32.c
@@ -468,7 +468,7 @@ void aEnvMixerImpl(const uint8_t flags, ENVMIX_STATE state) {
             /*
                Thanks to michi and Wuerfel_21 for help in optimizing the underlying math here.
 
-               The addition arguments are always 16-bit, good for SIMD32.
+               The addition arguments are always 16-bit, good for SIMD32 with qadd16.
 
                static data usage:
                 in:        read once

--- a/src/pc/mixer_implementations/mixer_3ds_simd32.c
+++ b/src/pc/mixer_implementations/mixer_3ds_simd32.c
@@ -391,6 +391,8 @@ static ALWAYS_INLINE int32_t envMixerGetVolumeDecreasing(const int32_t volume, c
 
 // Processes audio with the AUX flag, writing both dry and wet buffers.
 // Thanks to michi and Wuerfel_21 for help in optimizing the underlying math here.
+// Of note, SIMD32 could be used for the final addition when using inaccurate math.
+// However, I implemented this, and performance was a wash.
 static ALWAYS_INLINE void envMixerProcessAudioAux (
     const int16_t in_val,
     int16_t* dry[2],
@@ -414,6 +416,8 @@ static ALWAYS_INLINE void envMixerProcessAudioAux (
 
 // Processes audio without the AUX flag, writing only dry buffers.
 // Thanks to michi and Wuerfel_21 for help in optimizing the underlying math here.
+// Of note, SIMD32 could be used for the final addition when using inaccurate math.
+// However, I implemented this, and performance was a wash.
 static ALWAYS_INLINE void envMixerProcessAudioNormal (
     const int16_t in_val,
     int16_t* dry[2],

--- a/src/pc/profiler_3ds.h
+++ b/src/pc/profiler_3ds.h
@@ -9,10 +9,10 @@
 #if PROFILER_3DS_ENABLE == 1
 
 // Maximum ID number for a timestamp.
-#define PROFILER_3DS_NUM_IDS 256
+#define PROFILER_3DS_NUM_IDS 32
 
 // Number of frames to average in the circular buffer.
-#define PROFILER_3DS_NUM_CIRCULAR_FRAMES 30
+#define PROFILER_3DS_NUM_CIRCULAR_FRAMES 90
 
 // Maximum number of timestamps that can be stored without a reset.
 // Additional timestamps will be dropped.
@@ -22,6 +22,13 @@
 // value, it will trigger every snoop.
 #define PROFILER_3DS_NUM_TRACKED_SNOOP_IDS 64
 
+// Length of the log string.
+// For the circular log, estimate 30 * <max id> * num circular frames, plus some extra for formatting.
+#define PROFILER_3DS_LOG_STRING_LENGTH 24000
+
+// Convenience define. Represents where to place the buffer terminator.
+#define PROFILER_3DS_LOG_STRING_TERMINATOR (PROFILER_3DS_LOG_STRING_LENGTH - 1)
+
 #else
 
 // Profiler is disabled, so all values are 0 to reduce memory footprint.
@@ -29,6 +36,8 @@
 #define PROFILER_3DS_NUM_CIRCULAR_FRAMES 0
 #define PROFILER_3DS_TIMESTAMP_HISTORY_LENGTH 0
 #define PROFILER_3DS_NUM_TRACKED_SNOOP_IDS 0
+#define PROFILER_3DS_LOG_STRING_LENGTH 1
+#define PROFILER_3DS_LOG_STRING_TERMINATOR (PROFILER_3DS_LOG_STRING_LENGTH - 1)
 
 #endif
 
@@ -53,6 +62,7 @@ double profiler_3ds_linear_get_average_impl(uint32_t id); // Returns the average
 double profiler_3ds_circular_get_duration_impl(uint32_t frame, uint32_t id); // Returns the duration for a given frame and ID from the circular log.
 double profiler_3ds_circular_get_average_time_impl(uint32_t id); // Returns the average time for an ID from the circular log. Must be calculated first.
 void   profiler_3ds_set_snoop_counter_impl(uint32_t snoop_id, uint8_t frames_until_snoop); // Sets the interval for a snoop counter.
+int    profiler_3ds_create_log_string_circular_impl(uint32_t min_id_to_print, uint32_t max_id_to_print); // Creates a log string of the circular buffer and stores it in log_string. Returns 0 if successful, or -1 if the buffer could not fit the string.
 void   profiler_3ds_snoop_impl(uint32_t snoop_id); // Computes some useful information for the timestamps. Intended for debugger use.
 
 // Relays to the actual functions
@@ -72,13 +82,14 @@ void   profiler_3ds_snoop_impl(uint32_t snoop_id); // Computes some useful infor
 #define profiler_3ds_init()                           profiler_3ds_init_impl() // Initializes the snoop counters and resets all logs.
 
 // Getters, Inspectors, and Snoopers
-#define profiler_3ds_average_get_average(id)          profiler_3ds_average_get_average_impl(id) // Returns the average time from the long-term average log.
-#define profiler_3ds_linear_get_elapsed_time()        profiler_3ds_linear_get_elapsed_time_impl() // Returns the total elapsed time of the linear log in milliseconds.
-#define profiler_3ds_linear_get_average(id)           profiler_3ds_linear_get_average_impl(id) // Returns the average time for the given ID from the linear log in milliseconds. Must be calculated first.
-#define profiler_3ds_circular_get_total_time(f, id)   profiler_3ds_circular_get_total_time_impl(f, id) // Returns the duration for a given frame and ID from the circular log.
-#define profiler_3ds_circular_get_average_time(f, id) profiler_3ds_circular_get_average_time_impl(f, id) // Returns the average time for an ID from the circular log. Must be calculated first.
-#define profiler_3ds_set_snoop_counter(sid, ftl)      profiler_3ds_set_snoop_counter_impl(sid, ftl) // Sets the interval for a snoop counter.
-#define profiler_3ds_snoop(sid)                       profiler_3ds_snoop_impl(sid) // Computes some useful information for the timestamps. Intended for debugger use.
+#define profiler_3ds_average_get_average(id)              profiler_3ds_average_get_average_impl(id) // Returns the average time from the long-term average log.
+#define profiler_3ds_linear_get_elapsed_time()            profiler_3ds_linear_get_elapsed_time_impl() // Returns the total elapsed time of the linear log in milliseconds.
+#define profiler_3ds_linear_get_average(id)               profiler_3ds_linear_get_average_impl(id) // Returns the average time for the given ID from the linear log in milliseconds. Must be calculated first.
+#define profiler_3ds_circular_get_total_time(f, id)       profiler_3ds_circular_get_total_time_impl(f, id) // Returns the duration for a given frame and ID from the circular log.
+#define profiler_3ds_circular_get_average_time(f, id)     profiler_3ds_circular_get_average_time_impl(f, id) // Returns the average time for an ID from the circular log. Must be calculated first.
+#define profiler_3ds_set_snoop_counter(sid, ftl)          profiler_3ds_set_snoop_counter_impl(sid, ftl) // Sets the interval for a snoop counter.
+#define profiler_3ds_create_log_string_circular(min, max) profiler_3ds_create_log_string_circular_impl(min, max) // Creates a log string of the circular buffer and stores it in log_string. Returns 0 if successful, or -1 if the buffer could not fit the string.
+#define profiler_3ds_snoop(sid)                           profiler_3ds_snoop_impl(sid) // Computes some useful information for the timestamps. Intended for debugger use.
 
 // Stubs used when the profiler is disabled
 #else
@@ -98,8 +109,10 @@ void   profiler_3ds_snoop_impl(uint32_t snoop_id); // Computes some useful infor
 #define profiler_3ds_circular_get_total_time(frame, id)                          0.0 // Profiler is disabled.
 #define profiler_3ds_circular_get_average_time(frame, id)                        0.0 // Profiler is disabled.
 #define profiler_3ds_set_snoop_counter(snoop_id, frames_until_snoop) do {} while (0) // Profiler is disabled.
+#define profiler_3ds_create_log_string_circular(min, max)            do {} while (0) // Profiler is disabled.
+
 #define profiler_3ds_snoop(snoop_id)                                 do {} while (0) // Profiler is disabled.
 
-#endif
+#endif // PROFILER_3DS_ENABLE
 
-#endif
+#endif // PROFILER_3DS_H


### PR DESCRIPTION
Re-added a missing clamp16 to fix popping audio when AUDIO_USE_ACCURATE_MATH was set.

Did some ugly nasty optimization to the 3DS aEnvMixerImpl function. It looks gross but it IS faster. In fact, it's actually fast enough to more or less completely avoid that weird stuttering on old 3DS. Huzzah!