### PR TITLE
RC7 - Fix .cia Builds and Speed Up Sleep

### DIFF
--- a/3ds/template.rsf
+++ b/3ds/template.rsf
@@ -72,7 +72,7 @@ AccessControlInfo:
   IdealProcessor                : 0
   AffinityMask                  : 1
   Priority                      : 16
-  MaxCpu                        : 0
+  MaxCpu                        : 0xFF
   HandleTableSize               : 0x200
   DisableDebug                  : false
   EnableForceDebug              : false
@@ -118,6 +118,7 @@ AccessControlInfo:
     DuplicateHandle: 39
     ExitProcess: 3
     ExitThread: 9
+    FlushProcessDataCache: 84
     GetCurrentProcessorNumber: 17
     GetHandleInfo: 41
     GetProcessId: 53

--- a/enhancements/60fps.patch
+++ b/enhancements/60fps.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index 935ab8c..37cb564 100644
+index 780e51b..6033981 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -500,7 +500,7 @@ ifeq ($(TARGET_N3DS),1)
+@@ -504,7 +504,7 @@ ifeq ($(TARGET_N3DS),1)
    CTRULIB  :=  $(DEVKITPRO)/libctru
    LIBDIRS  := $(CTRULIB)
    export LIBPATHS  :=  $(foreach dir,$(LIBDIRS),-L$(dir)/lib)
@@ -1869,10 +1869,10 @@ index cd9f13c..abfb71e 100644
          gSPDisplayList(displayListIter++, &intro_seg7_dl_0700B3A0);
          gSPPopMatrix(displayListIter++, G_MTX_MODELVIEW);
 diff --git a/src/pc/gfx/gfx_3ds.c b/src/pc/gfx/gfx_3ds.c
-index 2d8bec7..d697910 100644
+index 008d9ec..37c1749 100644
 --- a/src/pc/gfx/gfx_3ds.c
 +++ b/src/pc/gfx/gfx_3ds.c
-@@ -34,9 +34,9 @@
+@@ -35,9 +35,9 @@
  
  // wait a quarter second between mashing
  #ifdef VERSION_EU

--- a/src/pc/audio/audio_3ds.c
+++ b/src/pc/audio/audio_3ds.c
@@ -134,7 +134,7 @@ static void audio_3ds_play_internal(const uint8_t *src, size_t len_total, size_t
     // DSP_FlushDataCache is slow if AppCpuLimit is set high for some reason.
     // svcFlushProcessDataCache is much faster and still works perfectly.
     // DSP_FlushDataCache(dst, len_total);
-    svcFlushProcessDataCache(CUR_PROCESS_HANDLE, dst, len_total);
+    svcFlushProcessDataCache(CUR_PROCESS_HANDLE, (Handle) dst, len_total);
     
     // Actually play the data
     sDspBuffers[sNextBuffer].nsamples = len_total / 4;
@@ -225,7 +225,7 @@ static void audio_3ds_initialize_thread()
     if (R_SUCCEEDED(svcSetThreadPriority(CUR_THREAD_HANDLE, N3DS_DESIRED_PRIORITY_MAIN_THREAD)))
         printf("Set main thread priority to 0x%x.\n", N3DS_DESIRED_PRIORITY_MAIN_THREAD);
     else
-        fprintf(perror, "Couldn't set main thread priority to 0x%x.\n", N3DS_DESIRED_PRIORITY_MAIN_THREAD);
+        fprintf(stderr, "Couldn't set main thread priority to 0x%x.\n", N3DS_DESIRED_PRIORITY_MAIN_THREAD);
 
     // Select core to use
     if (is_new_n3ds()) {
@@ -235,7 +235,7 @@ static void audio_3ds_initialize_thread()
         printf("AppCpuTimeLimit is %d.\nAppCpuIdleLimit is %d.\n", N3DS_AUDIO_CORE_1_LIMIT, N3DS_AUDIO_CORE_1_LIMIT_IDLE);
     } else {
         s_audio_cpu = OLD_CORE_0; // Run in Thread5
-        fprintf(perror, "Failed to set AppCpuTimeLimit to %d.\n", N3DS_AUDIO_CORE_1_LIMIT);
+        fprintf(stderr, "Failed to set AppCpuTimeLimit to %d.\n", N3DS_AUDIO_CORE_1_LIMIT);
     }
 
     // Create a thread if applicable

--- a/src/pc/audio/audio_3ds.c
+++ b/src/pc/audio/audio_3ds.c
@@ -29,21 +29,30 @@
 #define N3DS_DSP_DMA_BUFFER_SIZE 4096 * 4
 #define N3DS_DSP_N_CHANNELS 2
 
+// Definitions taken from libctru comments
 union NdspMix {
     float raw[12];
     struct {
-        float volume_left;
-        float volume_right;
-        float unknown_2;
-        float unknown_3;
-        float unknown_4;
-        float unknown_5;
-        float unknown_6;
-        float unknown_7;
-        float unknown_8;
-        float unknown_9;
-        float unknown_10;
-        float unknown_11;
+        struct {
+            float volume_left;
+            float volume_right;
+            float volume_back_left;
+            float volume_back_right;
+        } main;
+
+        struct {
+            float volume_left;
+            float volume_right;
+            float volume_back_left;
+            float volume_back_right;
+        } aux_0;
+
+        struct {
+            float volume_left;
+            float volume_right;
+            float volume_back_left;
+            float volume_back_right;
+        } aux_1;
     } mix;
 };
 
@@ -272,8 +281,8 @@ static void audio_3ds_initialize_dsp()
     ndspChnSetFormat(0, NDSP_FORMAT_STEREO_PCM16);
 
     memset(ndsp_mix.raw, 0, sizeof(ndsp_mix));
-    ndsp_mix.mix.volume_left = 1.0;
-    ndsp_mix.mix.volume_right = 1.0;
+    ndsp_mix.mix.main.volume_left = 1.0;
+    ndsp_mix.mix.main.volume_right = 1.0;
     ndspChnSetMix(0, ndsp_mix.raw);
 
     u8* bufferData = linearAlloc(N3DS_DSP_DMA_BUFFER_SIZE * N3DS_DSP_DMA_BUFFER_COUNT);
@@ -308,8 +317,8 @@ static void audio_3ds_stop(void)
 
 void audio_3ds_set_dsp_volume(float left, float right)
 {
-    ndsp_mix.mix.volume_left = left;
-    ndsp_mix.mix.volume_right = right;
+    ndsp_mix.mix.main.volume_left = left;
+    ndsp_mix.mix.main.volume_right = right;
     ndspChnSetMix(0, ndsp_mix.raw);
 }
 

--- a/src/pc/audio/audio_3ds.h
+++ b/src/pc/audio/audio_3ds.h
@@ -16,4 +16,7 @@ extern bool audio_3ds_next_buffer_is_ready();
 // Used in audio_3ds when multi-threaded and level_script when single-threaded
 extern void audio_3ds_run_one_frame();
 
+// Sets the volume of the NDSP directly.
+extern void audio_3ds_set_dsp_volume(float left, float right);
+
 #endif

--- a/src/pc/audio/audio_3ds_threading.h
+++ b/src/pc/audio/audio_3ds_threading.h
@@ -42,6 +42,8 @@
 // Audio sleep duration of 10 microseconds (0.01 millis). May sleep for longer.
 #define N3DS_AUDIO_SLEEP_DURATION_NANOS N3DS_AUDIO_MILLIS_TO_NANOS(0.01)
 
+#define N3DS_DESIRED_PRIORITY_MAIN_THREAD 0x19
+#define N3DS_DESIRED_PRIORITY_AUDIO_THREAD 0x18
 #define N3DS_AUDIO_CORE_1_LIMIT_IDLE 10 // Limit when in the home menu, sleeping, etc. Can be [10-80].
 #define N3DS_AUDIO_CORE_1_LIMIT 80      // Limit during gameplay. Can be [10-80].
 
@@ -71,7 +73,7 @@ extern enum N3dsCpu s_audio_cpu;
 extern volatile __3ds_s32 s_audio_frames_to_tick;
 extern volatile __3ds_s32 s_audio_frames_to_process;
 
-// This is purely an informative value.
+// This is a purely informative value.
 // It is set to true when it acknowledges a new frame to process,
 // and to false when the audio thread begins spinning.
 // Do not use this for bi-directional synchronization!

--- a/src/pc/gfx/gfx_3ds.c
+++ b/src/pc/gfx/gfx_3ds.c
@@ -257,7 +257,7 @@ static void gfx_3ds_apt_hook(APT_HookType hook, UNUSED void* param)
     // Wait for async audio to finish. Synchronous will already be done anyway.
     if (!s_thread5_does_audio) {
         while (appSuspendCounter > 0 && s_audio_thread_processing)
-            svcSleepThread(N3DS_AUDIO_SLEEP_DURATION_NANOS);
+            N3DS_AUDIO_SLEEP_FUNC(N3DS_AUDIO_SLEEP_DURATION_NANOS);
     }
 
     // Lower CPU priority only if applicable
@@ -325,7 +325,7 @@ static void gfx_3ds_main_loop(void (*run_one_game_iter)(void))
         if (appSuspendCounter == 0)
             run_one_game_iter();
         else
-            svcSleepThread(N3DS_AUDIO_MILLIS_TO_NANOS(33));
+            N3DS_AUDIO_SLEEP_FUNC(N3DS_AUDIO_MILLIS_TO_NANOS(33));
     }
 
     aptSetSleepAllowed(false);

--- a/src/pc/gfx/gfx_3ds.c
+++ b/src/pc/gfx/gfx_3ds.c
@@ -9,6 +9,7 @@
 #include "gfx_citro3d.h"
 
 #include "src/pc/audio/audio_3ds_threading.h"
+#include "src/pc/audio/audio_3ds.h"
 
 #define u64 __3ds_u64
 #define s64 __3ds_s64
@@ -254,11 +255,10 @@ static void gfx_3ds_apt_hook(APT_HookType hook, UNUSED void* param)
 
     printf("AptHook caught: %s.\n", eventName);
 
-    // Wait for async audio to finish. Synchronous will already be done anyway.
-    if (!s_thread5_does_audio) {
-        while (appSuspendCounter > 0 && s_audio_thread_processing)
-            N3DS_AUDIO_SLEEP_FUNC(N3DS_AUDIO_SLEEP_DURATION_NANOS);
-    }
+    // Mute audio when sleeping, unmute when waking
+    const float vol = appSuspendCounter > 0 ? 0.0f : 1.0f;
+    printf("Setting NDSP volume to: %f\n", vol);
+    audio_3ds_set_dsp_volume(vol, vol);
 
     // Lower CPU priority only if applicable
     if (s_audio_cpu == OLD_CORE_1) {

--- a/src/pc/profiler_3ds.c
+++ b/src/pc/profiler_3ds.c
@@ -1,4 +1,8 @@
 #include "profiler_3ds.h"
+
+// If the profiler is disabled, functions and their headers do not exist.
+#if PROFILER_3DS_ENABLE == 1
+
 #include <string.h>
 #include <stdio.h>
 
@@ -300,9 +304,6 @@ void profiler_3ds_set_snoop_counter_impl(uint32_t snoop_id, uint8_t frames_until
 int profiler_3ds_create_log_string_circular_impl(uint32_t min_id_to_print, uint32_t max_id_to_print) {
     log_string[0] = '\0';
     log_string[PROFILER_3DS_LOG_STRING_TERMINATOR] = '\0';
-
-    if (min_id_to_print < 0)
-        min_id_to_print = 0;
         
     if (min_id_to_print > PROFILER_3DS_NUM_IDS)
         min_id_to_print = PROFILER_3DS_NUM_IDS;
@@ -424,7 +425,7 @@ void profiler_3ds_snoop_impl(UNUSED uint32_t snoop_id) {
                     profiler_3ds_average_calculate_average_impl();
                     profiler_3ds_linear_calculate_averages_impl();
                     profiler_3ds_circular_calculate_averages_impl();
-                    volatile int log_len = profiler_3ds_create_log_string_circular_impl(0, 19);
+                    UNUSED volatile int log_len = profiler_3ds_create_log_string_circular_impl(0, 19);
                     
                     i += 5; // Place a breakpoint here
                     break;
@@ -439,3 +440,5 @@ void profiler_3ds_snoop_impl(UNUSED uint32_t snoop_id) {
 
     return; // Leave this here for breakpoints
 }
+
+#endif // #if PROFILER_3DS_ENABLE == 1

--- a/src/pc/profiler_3ds.h
+++ b/src/pc/profiler_3ds.h
@@ -41,6 +41,8 @@
 
 #endif
 
+// Function definitions and #define relays to them.
+#if PROFILER_3DS_ENABLE == 1
 
 // Loggers and Calculators
 void profiler_3ds_log_time_impl(uint32_t id); // Logs a time with the given ID.
@@ -65,8 +67,6 @@ void   profiler_3ds_set_snoop_counter_impl(uint32_t snoop_id, uint8_t frames_unt
 int    profiler_3ds_create_log_string_circular_impl(uint32_t min_id_to_print, uint32_t max_id_to_print); // Creates a log string of the circular buffer and stores it in log_string. Returns 0 if successful, or -1 if the buffer could not fit the string.
 void   profiler_3ds_snoop_impl(uint32_t snoop_id); // Computes some useful information for the timestamps. Intended for debugger use.
 
-// Relays to the actual functions
-#if PROFILER_3DS_ENABLE == 1
 
 // Loggers and Calculators
 #define profiler_3ds_log_time(id)                     profiler_3ds_log_time_impl(id) // Logs a time with the given ID.
@@ -91,7 +91,7 @@ void   profiler_3ds_snoop_impl(uint32_t snoop_id); // Computes some useful infor
 #define profiler_3ds_create_log_string_circular(min, max) profiler_3ds_create_log_string_circular_impl(min, max) // Creates a log string of the circular buffer and stores it in log_string. Returns 0 if successful, or -1 if the buffer could not fit the string.
 #define profiler_3ds_snoop(sid)                           profiler_3ds_snoop_impl(sid) // Computes some useful information for the timestamps. Intended for debugger use.
 
-// Stubs used when the profiler is disabled
+// Stubs used when the profiler is disabled. Also note that functions aren't even defined.
 #else
 
 #define profiler_3ds_log_time(id)                                    do {} while (0) // Profiler is disabled.


### PR DESCRIPTION
- Fixed .cia builds crashing immediately on o3DS. This was due to an RSF header error, specifically the MaxCpu parameter.
- The 3DS sleep macro is now used everywhere, instead of using svcSleepThread directly in the level script.
- Thread priority is now set explicitly, and the thread creation logic is robust, and it logs more.
- The main thread no longer waits for the audio thread to finish synthesis & DSP export when entering sleep. Instead, it simply mutes and unmutes the DSP. This was *intended* to fix a semi-random crash related to closing the lid, but the issue persists. I am considering it an upstream issue until further notice, and I will discuss it with MKST. I am keeping the change intact because it speeds up sleep slightly, which was previously pretty sluggish on o3DS.
- Fixed build warnings and updated patches