### PR TITLE
Enable D-Pad Binding and Document Button Remapping

### DIFF
--- a/3DS_CONTROLLER_REMAPPING.md
+++ b/3DS_CONTROLLER_REMAPPING.md
@@ -2,6 +2,8 @@
 
 This document describes how to remap controls for SM643DS using the `sm64config.txt` configuration file.
 
+[This](https://codepen.io/benoitcaron/full/abNZrbP) online editor from [BenoitCaron](https://github.com/BenoitCaron) is usable, but it does not support remapping of all buttons.
+
 ## Caveats and Limitations
 
 - All of the N64 and 3DS buttons are available to remap except for the N64 Analog Stick and 3DS Circle Pad, as their mapping is hard-coded.
@@ -69,5 +71,4 @@ The following 3DS buttons are supported by SM643DS.
 - The 3DS Circle Pad can actually be bound to N64 buttons, but it cannot be unbound from the N64 Analog Stick from within `sm64config.txt,` so its codes were omitted here.
 - The Touch Screen's virtual buttons cannot currently be edited.
 - When running on the Old 3DS, mapping buttons only present on the New 3DS is harmless.
-- [This](https://codepen.io/benoitcaron/full/abNZrbP) online editor from [BenoitCaron](https://github.com/BenoitCaron) is usable, but it does not support remapping of all buttons.
 - If duplicate config entries exist in `sm64config.txt,` the last entry will be the only one used.

--- a/3DS_CONTROLLER_REMAPPING.md
+++ b/3DS_CONTROLLER_REMAPPING.md
@@ -1,0 +1,73 @@
+# Super Mario 64 Nintendo 3DS Port Controller Remapping Guide
+
+This document describes how to remap controls for SM643DS using the `sm64config.txt` configuration file.
+
+## Caveats and Limitations
+
+- All of the N64 and 3DS buttons are available to remap except for the N64 Analog Stick and 3DS Circle Pad, as their mapping is hard-coded.
+- Only the Player 1 controller can be used.
+- On older versions of the 3DS port, and also currently on the PC port, the N64 D-Pad was not mappable, as the vanilla game only uses it for debug controls. This port allows mapping the N64 D-Pad, so ensure that your version is up-to-date if you wish to use it.
+
+## How to Find `sm64config.txt`
+
+Run the game once and search your SD card for `sm64config.txt`.
+- When running from a 3DSX, it should appear next to the 3DSX file.
+- When running from an installed CIA file, it should appear in your SD card's root.
+- When launching remotely via 3DSLink, it should appear in your SD card's root.
+
+## How to Edit `sm64config.txt`
+
+Inside of `sm64config.txt,` you will find various `key_` variables, followed by a number, and separated by a space. The `key_` variables represent the N64 controller's inputs, and the number represents the 3DS's inputs.
+
+Every available 3DS input is represented by a single bit in a binary number. For example, A is the first bit, and B is the second bit. The full list can be found [below](#3ds-button-definitions). However, these numbers are stored in `sm64config.txt` as decimal numbers, which is why they may look nonsensical.
+
+To map a button, simply copy the button code from the [definitions](#3ds-button-definitions) below into your `sm64config.txt,` replacing the existing number for that `key_` input.
+
+To unmap a button, replace its button code with a `0.`
+
+## Mapping Multiple 3DS Buttons to One N64 Button
+
+Mapping multiple 3DS buttons to one N64 button requires mathematically adding each button code.
+
+For example, to map the N64 Z Button to both the 3DS L Button and the 3DS R button, do as follows:
+```
+3DS L Button: 512
+3DS R Button: 256
+
+512 + 256 = 768
+```
+
+Then, write `key_z 768` to `sm64config.txt,` replacing the existing value if required.
+
+## 3DS Button Definitions
+The following 3DS buttons are supported by SM643DS.
+```
+    Code        3DS Button
+─────────────┬────────────────
+         1   │    A Button
+         2   │    B Button
+         4   │    Select Button
+         8   │    Start Button
+        16   │    D-Pad Right
+        32   │    D-Pad Left
+        64   │    D-Pad Up
+       128   │    D-Pad Down
+       256   │    R Button
+       512   │    L Button
+      1024   │    X Button
+      2048   │    Y Button
+     16384   │    ZL Button (New 3DS only)
+     32768   │    ZR Button (New 3DS only)
+  16777216   │    C-Stick Right (New 3DS only)
+  33554432   │    C-Stick Left (New 3DS only)
+  67108864   │    C-Stick Up (New 3DS only)
+ 134217728   │    C-Stick Down (New 3DS only)
+```
+
+## Notes
+
+- The 3DS Circle Pad can actually be bound to N64 buttons, but it cannot be unbound from the N64 Analog Stick from within `sm64config.txt,` so its codes were omitted here.
+- The Touch Screen's virtual buttons cannot currently be edited.
+- When running on the Old 3DS, mapping buttons only present on the New 3DS is harmless.
+- [This](https://codepen.io/benoitcaron/full/abNZrbP) online editor from [BenoitCaron](https://github.com/BenoitCaron) is usable, but it does not support remapping of all buttons.
+- If duplicate config entries exist in `sm64config.txt,` the last entry will be the only one used.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A prior copy of the game is required to extract the assets.
      - Use the PC port's original audio emulation by building with `FORCE_REFERENCE_RSPA=1`. This should not impact quality, but may be useful for debugging, and will override `DISABLE_ENHANCED_RSPA`.
      - By default, 3DS audio uses some inaccurate math to increase performance with no perceptible loss in quality. To disable this, build with `AUDIO_USE_ACCURATE_MATH=1`. This may have no effect depending on the audio implementation being used; for example, Reference RSPA ignores this flag.
  - Configurable controls via `sm64config.txt`
-     - Use [this](https://codepen.io/benoitcaron/full/abNZrbP) online editor from [BenoitCaron](https://github.com/BenoitCaron).
+     - See [3DS_CONTROLLER_REMAPPING.md](3DS_CONTROLLER_REMAPPING.md).
  - GFX_POOL_SIZE [fix](https://github.com/aboood40091/sm64-port/commit/6ae4f4687ed234291ac1e572b75d65191ca9f364) (support 60 FPS on 32bit platforms)
  - Mini-menu (tap touch-screen to trigger)
      - Enable/disable AA

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -51,6 +51,10 @@ unsigned int configKeyStickUp    = 0x11;
 unsigned int configKeyStickDown  = 0x1F;
 unsigned int configKeyStickLeft  = 0x1E;
 unsigned int configKeyStickRight = 0x20;
+unsigned int configKeyDUp        = 0xFFFF; // Unbound
+unsigned int configKeyDDown      = 0xFFFF;
+unsigned int configKeyDLeft      = 0xFFFF;
+unsigned int configKeyDRight     = 0xFFFF;
 #else
 unsigned int configKeyA          = KEY_A | KEY_Y;
 unsigned int configKeyB          = KEY_B | KEY_X;
@@ -66,6 +70,10 @@ unsigned int configKeyStickUp    = 0;
 unsigned int configKeyStickDown  = 0;
 unsigned int configKeyStickLeft  = 0;
 unsigned int configKeyStickRight = 0;
+unsigned int configKeyDUp        = 0;
+unsigned int configKeyDDown      = 0;
+unsigned int configKeyDLeft      = 0;
+unsigned int configKeyDRight     = 0;
 #endif
 
 
@@ -81,6 +89,10 @@ static const struct ConfigOption options[] = {
     {.name = "key_cdown",      .type = CONFIG_TYPE_UINT, .uintValue = &configKeyCDown},
     {.name = "key_cleft",      .type = CONFIG_TYPE_UINT, .uintValue = &configKeyCLeft},
     {.name = "key_cright",     .type = CONFIG_TYPE_UINT, .uintValue = &configKeyCRight},
+    {.name = "key_dup",        .type = CONFIG_TYPE_UINT, .uintValue = &configKeyDUp},
+    {.name = "key_ddown",      .type = CONFIG_TYPE_UINT, .uintValue = &configKeyDDown},
+    {.name = "key_dleft",      .type = CONFIG_TYPE_UINT, .uintValue = &configKeyDLeft},
+    {.name = "key_dright",     .type = CONFIG_TYPE_UINT, .uintValue = &configKeyDRight},
 #ifndef TARGET_N3DS
     {.name = "key_stickup",    .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickUp},
     {.name = "key_stickdown",  .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickDown},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -16,6 +16,10 @@ extern unsigned int configKeyStickUp;
 extern unsigned int configKeyStickDown;
 extern unsigned int configKeyStickLeft;
 extern unsigned int configKeyStickRight;
+extern unsigned int configKeyDUp;
+extern unsigned int configKeyDDown;
+extern unsigned int configKeyDLeft;
+extern unsigned int configKeyDRight;
 
 void configfile_load(const char *filename);
 void configfile_save(const char *filename);

--- a/src/pc/controller/controller_3ds.c
+++ b/src/pc/controller/controller_3ds.c
@@ -37,7 +37,7 @@
 
 #include "../configfile.h"
 
-static int button_mapping[10][2];
+static int button_mapping[14][2];
 
 static void set_button_mapping(int index, int mask_n64, int mask_3ds)
 {
@@ -80,7 +80,7 @@ static u32 controller_3ds_get_held(void)
 
 static void controller_3ds_init(void)
 {
-    u32 i;
+    u32 i = 0;
     set_button_mapping(i++, A_BUTTON,     configKeyA); // n64 button => configured button
     set_button_mapping(i++, B_BUTTON,     configKeyB);
     set_button_mapping(i++, START_BUTTON, configKeyStart);
@@ -91,6 +91,10 @@ static void controller_3ds_init(void)
     set_button_mapping(i++, D_CBUTTONS,   configKeyCDown);
     set_button_mapping(i++, L_CBUTTONS,   configKeyCLeft);
     set_button_mapping(i++, R_CBUTTONS,   configKeyCRight);
+    set_button_mapping(i++, U_JPAD,       configKeyDUp);
+    set_button_mapping(i++, D_JPAD,       configKeyDDown);
+    set_button_mapping(i++, L_JPAD,       configKeyDLeft);
+    set_button_mapping(i++, R_JPAD,       configKeyDRight);
 }
 
 static void controller_3ds_read(OSContPad *pad)


### PR DESCRIPTION
- The D-Pad can now be bound from within `sm64config.txt.`
- Fixed a bug in `controller_3ds.c` that instantly crashed the game when building with -O0. Essentially, an uninitialized index value would cause an out-of-bouds array access and a segfault. This index is now initialized to 0.
- Added documentation for control remapping.